### PR TITLE
[develop] Squashed commit of the following:

### DIFF
--- a/rvi/src/main/java/com/jaguarlandrover/rvi/BluetoothConnection.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/BluetoothConnection.java
@@ -54,7 +54,7 @@ class BluetoothConnection implements RemoteConnectionInterface
         if (!isConnected() || !isConfigured()) // TODO: Call error on listener
             return;
 
-        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);//, dlinkPacket.toJsonString());
+        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);//, dlinkPacket.toJsonString());
     }
 
     @Override
@@ -97,7 +97,7 @@ class BluetoothConnection implements RemoteConnectionInterface
         Log.d(TAG, "Connecting to device: " + mDeviceAddress + ":" + mServiceRecord + ":" + mChannel);
 
         ConnectTask connectAndAuthorizeTask = new ConnectTask(mDeviceAddress, mServiceRecord, mChannel);
-        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     private class ConnectTask extends AsyncTask<Void, String, Throwable>
@@ -186,7 +186,7 @@ class BluetoothConnection implements RemoteConnectionInterface
                 Log.d(TAG, "Connecting Bluetooth socket: Creating listener...");
 
                 ListenTask listenTask = new ListenTask();
-                listenTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                listenTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
 
                 if (mRemoteConnectionListener != null)
                     mRemoteConnectionListener.onRemoteConnectionDidConnect();

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/DlinkReceivePacket.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/DlinkReceivePacket.java
@@ -59,11 +59,7 @@ class DlinkReceivePacket extends DlinkPacket
         super(Command.RECEIVE);
 
         mMod = "proto_json_rpc";
-        mService = service;
-
-
-        // TODO: With this paradigm, if one of the parameters of mService changes, mData string will still be the same.
-        //mData = mService.jsonString();//Base64.encodeToString(mService.jsonString().getBytes(), Base64.DEFAULT);
+        mService = service.copy();
     }
 
 //    public DlinkReceivePacket(HashMap jsonHash) {

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
@@ -49,7 +49,7 @@ class ServerConnection implements RemoteConnectionInterface
             return;
         }
 
-        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);//, dlinkPacket.toJsonString());
+        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);//, dlinkPacket.toJsonString());
     }
 
     @Override
@@ -93,7 +93,7 @@ class ServerConnection implements RemoteConnectionInterface
         Log.d(TAG, "Connecting the socket: " + mServerUrl + ":" + mServerPort);
 
         ConnectTask connectAndAuthorizeTask = new ConnectTask(mServerUrl, mServerPort, mServerKeyStore, mClientKeyStore, mClientKeyStorePassword);
-        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     private class ConnectTask extends AsyncTask<Void, String, Throwable>
@@ -200,7 +200,7 @@ class ServerConnection implements RemoteConnectionInterface
             if (result == null) {
                 // TODO: Does the input buffer stream cache data in the case that my async thread sends the auth command before the listener is set up?
                 ListenTask listenTask = new ListenTask();
-                listenTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                listenTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
 
                 if (mRemoteConnectionListener != null)
                     mRemoteConnectionListener.onRemoteConnectionDidConnect();

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/Service.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/Service.java
@@ -135,6 +135,10 @@ class Service
         return mNodeIdentifier != null;
     }
 
+    private String getNodeIdentifier() {
+        return mNodeIdentifier;
+    }
+
     /**
      * Sets the node identifier portion of the fully-qualified service name
      *
@@ -218,5 +222,14 @@ class Service
      */
     void setTimeout(Long timeout) {
         mTimeout = timeout;
+    }
+
+    public Service copy() {
+        Service copy = new Service(this.getServiceIdentifier(), this.getDomain(), this.getBundleIdentifier(), this.getNodeIdentifier());
+
+        copy.setTimeout(this.getTimeout());
+        copy.setParameters(this.getParameters());
+
+        return null;
     }
 }


### PR DESCRIPTION
commit 4322c12312b30c5b5f56315d3dc93f51a4384d29
Merge: b490263 b5b91da
Author: Lilli Szafranski lillialexis@gmail.com
Date:   Wed Sep 28 15:20:15 2016 -0700

```
Merge pull request #13 from lillialexis/RCA-39

[RCA-39] Made it so that queued pending service invocations all go ou…
```

commit b490263eceb01462fe6176c7dcf4d3a4bf99c4c4
Merge: 9192c98 62253c0
Author: Lilli Szafranski lillialexis@gmail.com
Date:   Wed Sep 28 15:19:48 2016 -0700

```
Merge pull request #12 from lillialexis/RCA-38

[RCA-38] When sending a service invocation, service object is copied …
```

commit b5b91da962d899690034d2f6b33cc063ad7d0f40
Author: Lilli Szafranski (Jaguar - Land Rover) lszafran@jaguarlandrover.com
Date:   Wed Sep 28 15:17:48 2016 -0700

```
[RCA-39] Made it so that queued pending service invocations all go out all at once, as opposed to only sending the last-invoked invocation, in the order they were received. Changed all the network-related background thread execution to be serial to guarantee order stays correct. Not really tested though.

(cherry picked from commit 993b0592d4bc10e6faf1245e8fed680d999899ff)
```

commit 62253c0a705f7071f072e6b04468df9d30b33e37
Author: Lilli Szafranski (Jaguar - Land Rover) lszafran@jaguarlandrover.com
Date:   Wed Sep 28 14:50:28 2016 -0700

```
[RCA-38] When sending a service invocation, service object is copied into dlink packet so subsequent invocations don't overwrite the parameters.

(cherry picked from commit 3c8e5db8ce3825d43470eb58513c1969536fe7c2)
```

commit 9192c986b97acc263881be8cf1fa3aaef6aaf64d
Merge: c51921d 2d14a9e
Author: Lilli Szafranski lillialexis@gmail.com
Date:   Mon Aug 8 14:52:57 2016 -0700

```
Merge pull request #11 from lillialexis/RCA-19

[RCA-19] ServerConnection line 280 catch all exceptions, not just IO
```

commit 2d14a9eca1e621d7a4fc919f0ea04bc630611b89
Author: Lilli Szafranski (Jaguar - Land Rover) lszafran@jaguarlandrover.com
Date:   Mon Aug 1 13:25:52 2016 -0700

```
[RCA-19] ServerConnection line 280 catch all exceptions, not just IO

(cherry picked from commit 7f2d26530558336d1a226918f3221464fb09db55)
```

****\* NOTE *****

The last commit, RCA-19, actually got squashed into the hvac project in the last set of commits: b6f988fc0c8916a38483f414c50e62cdc0ab07e4, and 18314b52eed3175e2d1da53d970c92e70a20a08e!
